### PR TITLE
V0.5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ auth = "basic"
 - Parse a local file
 
   ```js
-  const config = parse('../config.toml');
+  const config = parse('src/configs/config.toml');
 
   /**
    {
@@ -117,7 +117,7 @@ auth = "basic"
   > NOTE: you can also specify the file type if the extension does not match the file format
 
   ```js
-  const config = parse('../config.txt', 'toml');
+  const config = parse('src/configs/config.txt', { type: 'toml' });
   ```
 
 - Retrieve the parsed configurationn object
@@ -142,7 +142,63 @@ auth = "basic"
    */
   ```
 
+- Update configuration file
+
+  ```js
+  const updatedConfig = update({ newConfig: 'updated' });
+  ```
+
 ---
+
+## Parse configuration
+
+To parse the configuration, you can use the `parse` function. The function accepts 2 arguments:
+
+- The file path - relative to the root directory of the project
+- An object to specify options (optional)
+
+```js
+// The type is inferred
+const config = parse('src/configs/.env');
+
+// or
+
+// The type must be specified because the file extension does not match the format type
+const config = parse('src/config/config.txt', { type: 'dotenv' });
+```
+
+## Dynamically update config file
+
+To update the existing configuration or create a new file and subscribe to it, you can use the `update` function. The function accepts 2 arguments:
+
+- The new configuration object or a callback similar to React's useState hook.
+
+```js
+// Override configuration
+const updatedConfig = update({ override: true });
+
+// or
+
+// Add additional fields to existing configuration
+const updatedConfig = update((prev) => ({
+  ...prev,
+  additionalSection: {
+    updatedConfig: true,
+  },
+}));
+
+// Create a new configuration file and subscribe to it
+const updateConfig = update(
+  { newConfig: true, version: '0.2.0' },
+  {
+    createNewFile: true,
+    newFileOptions: {
+      path: 'src/configs/newConfig.json', // if the file already exists, it will override its content.
+      type: 'json', // optional. Type will be inferred from the file name
+    },
+  }
+);
+```
 
 ## Remote Configurations (STILL IN PROGRESS)
 
@@ -151,7 +207,8 @@ Currently, the library supports retrieving files from AWS S3 Buckets and Azure B
 - AWS:
 
 ```js
-const config = parse('config_on_aws', 'toml', {
+const config = parse('config_on_aws', {
+  type: 'json',
   fromCloud: true,
   cloudConfig: {
     aws: {
@@ -168,7 +225,8 @@ const config = parse('config_on_aws', 'toml', {
 - Azure:
 
 ```js
-const config = parse('config_on_azure', 'toml', {
+const config = parse('config_on_azure', {
+  type: 'ini',
   fromCloud: true,
   cloudConfig: {
     azure: {
@@ -187,7 +245,7 @@ const config = parse('config_on_azure', 'toml', {
 The library supports hot reloading of the config file. Set the `hotReload` to `true`
 
 ```js
-const config = parse('../config.toml', 'toml', {
+const config = parse('../config.toml', {
   hotReload: true,
   hotReloadInterval: 2000, // in ms. Default: 1000ms
 });

--- a/README.md
+++ b/README.md
@@ -76,21 +76,19 @@ import { parse, getConfig } from 'confignition';
 
 - For the following example config:
 
-```toml
-[server]
-host = "localhost"
-port = 5000
+  ```toml
+  [server]
+  host = "localhost"
+  port = 5000
 
-[database]
-url = "postgres://username:password@localhost/mydatabase"
+  [database]
+  url = "postgres://username:password@localhost/mydatabase"
 
 
-[[database.options]]
-https = true
-auth = "basic"
-```
-
----
+  [[database.options]]
+  https = true
+  auth = "basic"
+  ```
 
 - Parse a local file
 
@@ -99,17 +97,8 @@ auth = "basic"
 
   /**
    {
-    server: {
-        port: 5000,
-        host: 'localhost',
-    },
-    database: {
-        url: 'postgres://username:password@localhost/mydatabase',
-        options: {
-            https: true,
-            auth: 'basic'
-        }
-    }
+    port: 5000,
+    host: 'localhost',
    }
    */
   ```
@@ -127,17 +116,8 @@ auth = "basic"
 
   /**
    {
-    server: {
-        port: 5000,
-        host: 'localhost',
-    },
-    database: {
-        url: 'postgres://username:password@localhost/mydatabase',
-        options: {
-            https: true,
-            auth: 'basic'
-        }
-    }
+    port: 5000,
+    host: 'localhost',
    }
    */
   ```
@@ -166,6 +146,8 @@ const config = parse('src/configs/.env');
 // The type must be specified because the file extension does not match the format type
 const config = parse('src/config/config.txt', { type: 'dotenv' });
 ```
+
+---
 
 ## Dynamically update config file
 
@@ -199,6 +181,8 @@ const updateConfig = update(
   }
 );
 ```
+
+---
 
 ## Remote Configurations (STILL IN PROGRESS)
 

--- a/src/converter.ts
+++ b/src/converter.ts
@@ -1,0 +1,81 @@
+import { Config, GlobalState } from './types';
+import { writeFileSync } from 'fs';
+import { stringify } from 'yaml';
+
+const _writeToFile = (content: string, filePath: string) => {
+  writeFileSync(filePath, content);
+};
+
+const _stringifyEnv = (config: Config, prefix = ''): string => {
+  let content = '';
+  for (const [key, value] of Object.entries(config)) {
+    const fullKey = prefix ? `${prefix}.${key}` : key;
+    if (typeof value === 'object') {
+      content += _stringifyEnv(value, fullKey);
+    } else {
+      content += `${fullKey}=${value}\n`;
+    }
+  }
+  return content;
+};
+
+const _stringifyToml = (config: Config, header = '') => {
+  let content = '';
+  for (const [key, value] of Object.entries(config)) {
+    if (typeof value === 'object') {
+      const fullHeader = header ? `${header}.${key}` : `${key}`;
+      if (header) {
+        content += `[[${fullHeader}]]\n${_stringifyToml(value, fullHeader)}`;
+      } else {
+        content += `[${fullHeader}]\n${_stringifyToml(value, fullHeader)}\n`;
+      }
+    } else {
+      content += `${key} = ${JSON.stringify(value)}\n`;
+    }
+  }
+  return content;
+};
+
+const _stringifyIni = (config: Config, header = '') => {
+  let content = '';
+  for (const [key, value] of Object.entries(config)) {
+    if (typeof value === 'object') {
+      const fullHeader = header ? `${header}.${key}` : `${key}`;
+      content += `\n[${fullHeader}]\n${_stringifyIni(value, fullHeader)}`;
+    } else {
+      content += `${key}=${JSON.stringify(value)}\n`;
+    }
+  }
+  return content;
+};
+
+const _toEnv = (state: GlobalState) => {
+  const content = _stringifyEnv(state.config || {});
+  _writeToFile(content, state.filePath);
+};
+const _toToml = (state: GlobalState) => {
+  const content = _stringifyToml(state.config || {});
+  _writeToFile(content, state.filePath);
+};
+const _toYaml = (state: GlobalState) => {
+  const content = stringify(state.config || {});
+  _writeToFile(content, state.filePath);
+};
+const _toJson = (state: GlobalState) => {
+  const content = JSON.stringify(state.config || {}, null, 2);
+  _writeToFile(content, state.filePath);
+};
+const _toIni = (state: GlobalState) => {
+  const content = _stringifyIni(state.config || {});
+  _writeToFile(content, state.filePath);
+};
+
+const converter = {
+  toEnv: _toEnv,
+  toToml: _toToml,
+  toYaml: _toYaml,
+  toJson: _toJson,
+  toIni: _toIni,
+};
+
+export default converter;

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@ import { join, resolve, dirname } from 'path';
 import { watchFile, Stats } from 'fs';
 import parser from './parser';
 import { _getConfig, _getErrMsg, _parseFileType } from './utils';
-import { AllowedFileTypes, Config, GlobalState, ParseOptions, UpdateOptions } from './types';
+import { Config, GlobalState, ParseOptions, UpdateOptions } from './types';
 import cloud from './cloud';
 import converter from './converter';
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -57,18 +57,17 @@ const _watchConfig = (interval = 1000) => {
 /**
  *
  * @param {string} filePath the path to evaluate.
- * @param {AllowedFileTypes} type the optional file type. If not provided, it will be inferred from the extension.
  * @param {ParseOptions} options options for advanced parsing, such as encryption and cloud.
  * @returns {Config | null} parsed config.
  * @throws {Error} if file extension is not allowed.
  */
-export const parse = (file: string, type?: AllowedFileTypes, options: ParseOptions = _parseOptions): Config | null => {
+export const parse = (file: string, options: ParseOptions = _parseOptions): Config | null => {
   try {
-    if (!type) {
-      type = _parseFileType(file);
+    if (!options.type) {
+      options.type = _parseFileType(file);
     }
 
-    state.type = type;
+    state.type = options.type;
     state.filePath = join(resolve(dirname('')), file);
     let content = '';
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,6 +12,7 @@ export interface Config {
  * Interface containing options for the parse() function.
  */
 export interface ParseOptions {
+  type?: AllowedFileTypes;
   fromCloud?: boolean;
   cloudConfig?: ParseCloudOptions;
   hotReload?: boolean;

--- a/src/types.ts
+++ b/src/types.ts
@@ -52,3 +52,20 @@ export const allowedFileTypes = ['dotenv', 'toml', 'yaml', 'yml', 'json', 'ini']
  * Type grouping the extensions allowed for the configuration file.
  */
 export type AllowedFileTypes = (typeof allowedFileTypes)[number];
+
+/**
+ * Options to update configurations.
+ */
+export interface UpdateOptions {
+  createNewFile?: boolean;
+  newFileOptions?: {
+    path: string;
+    type?: AllowedFileTypes;
+  };
+}
+
+export interface GlobalState {
+  config: Config;
+  type: AllowedFileTypes | null;
+  filePath: string;
+}


### PR DESCRIPTION
- Added functionality to update/override config file or create a new one and subscribe to it
- Modified parse function parameters:
  - Moved `type` inside the options object for simplicity.
- Updated README.md
- Specified that the path needs to be relative from the root directory
- Added functionality to retrieve the entire state (config, type, filePath). Additional properties, such as parse options, are not included